### PR TITLE
Revert uClibC arc4random, plus documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ CSPRNG, stands for "Cryptographically-Secure Pseudo-Random Number Generator."
 This library relies upon existing system sources for cryptographic randomness.
 
 When compiled on Windows, it uses the `BCryptGenRandom`, `CryptGenRandom`, or
-`RtlGenRandom` system APIs. When compiled on Linux, OpenBSD, or NetBSD, it
-reads random bytes from `/dev/random`. When compiled on Mac OS X, FreeBSD, or
-DragonFlyBSD, it reads random bytes from the `arc4random_buf` function in the
+`RtlGenRandom` system APIs. When compiled on Linux, FreeBSD, or DragonFlyBSD,
+it reads random bytes from `/dev/random`. When compiled on Mac OS X, OpenBSD,
+or NetBSD, it reads random bytes from the `arc4random_buf` function in the
 C runtime library. Regardless of underlying operating system, it resorts to
-the `arc4random_buf` function if the Bionic C Library or uClibc C Library is
-in use.
+the `arc4random_buf` function if the Bionic C Library is in use.
 
 ## Building and Installing
 

--- a/source/csprng/system.d
+++ b/source/csprng/system.d
@@ -21,10 +21,6 @@ version (CRuntime_Bionic)
 {
     version = SecureARC4Random;
 }
-else version (CRuntime_UClibc)
-{
-    version = SecureARC4Random;
-}
 
 /* NOTE:
     Why not use $(D arc4random_buf) on FreeBSD or DragonFlyBSD?


### PR DESCRIPTION
uClibC `arc4random_buf` still uses ARC4:
https://git.uclibc.org/uClibc/tree/libc/stdlib/arc4random.c